### PR TITLE
Update groups

### DIFF
--- a/core/migrations/0002_groupinvitation.py
+++ b/core/migrations/0002_groupinvitation.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_squashed_0020_merge'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='GroupInvitation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('inviting', models.BooleanField(default=True)),
+                ('group', models.ForeignKey(to='core.Group')),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -157,12 +157,12 @@ class GroupInvitation(models.Model):
     def create(cls, group, user, inviting):
         invite = cls(user=user, group=group, inviting=inviting)
         invite.save()
-        if not inviting:
-            invite.group.push_notification('A user has requested to join your group.',
-                                           reverse('core:invite', kwargs={'pk': invite.id}))
-        else:
+        if inviting:
             invite.user.push_notification('A group has requested you join.',
                                           reverse('core:invite', kwargs={'pk': invite.id}))
+        else:
+            invite.group.push_notification('A user has requested to join your group.',
+                                           reverse('core:invite', kwargs={'pk': invite.id}))
 
 
 class GameTag(models.Model):

--- a/core/models.py
+++ b/core/models.py
@@ -131,8 +131,8 @@ class Group(models.Model):
 class GroupInvitation(models.Model):
     """An invitation for a group."""
 
-    user = models.ForeignKey(User)
-    group = models.ForeignKey(Group)
+    user = models.ForeignKey(User, null=False)
+    group = models.ForeignKey(Group, null=False)
     inviting = models.BooleanField(null=False, default=True)
 
     # For the inviting field here:

--- a/core/models.py
+++ b/core/models.py
@@ -121,6 +121,18 @@ class Group(models.Model):
         return self.name
 
 
+class GroupInvitation(models.Model):
+    """An invitation for a group."""
+
+    user = models.ForeignKey(User)
+    group = models.ForeignKey(Group)
+    inviting = models.BooleanField(null=False, default=True)
+
+    # For the inviting field here:
+    # true: this is an invation from the group to the user
+    # false: this is a request from the user to join the group
+
+
 class GameTag(models.Model):
     """Tags to label Games."""
 

--- a/core/models.py
+++ b/core/models.py
@@ -132,6 +132,18 @@ class GroupInvitation(models.Model):
     # true: this is an invation from the group to the user
     # false: this is a request from the user to join the group
 
+    def accept(self):
+        self.group.members.add(self.user)
+        self.group.save()
+        self.delete()
+
+    def decline(self):
+        self.delete()
+
+    def valid_user(self, user):
+        return ((self.inviting and user == self.user) or
+                (not self.inviting and user in self.group.members.all()))
+
 
 class GameTag(models.Model):
     """Tags to label Games."""

--- a/core/models.py
+++ b/core/models.py
@@ -158,11 +158,12 @@ class GroupInvitation(models.Model):
         invite = cls(user=user, group=group, inviting=inviting)
         invite.save()
         if inviting:
-            invite.user.push_notification('A group has requested you join.',
+            invite.user.push_notification('A group has invited you to join.',
                                           reverse('core:invite', kwargs={'pk': invite.id}))
         else:
             invite.group.push_notification('A user has requested to join your group.',
                                            reverse('core:invite', kwargs={'pk': invite.id}))
+        return invite
 
 
 class GameTag(models.Model):

--- a/core/static/js/invite.js
+++ b/core/static/js/invite.js
@@ -1,0 +1,12 @@
+function sendResponse(val){
+    var pathname = window.location.pathname; 
+    $.post(pathname, {accept: val}, function(data){
+        window.location.href = data.url;
+    });
+}
+
+function accept(){sendResponse(true);}
+function decline(){sendResponse(true);}
+
+$('#acceptBtn').click(accept);
+$('#declineBtn').click(decline);

--- a/core/static/js/invite.js
+++ b/core/static/js/invite.js
@@ -1,6 +1,6 @@
 function sendResponse(val){
-    var pathname = window.location.pathname; 
-    $.post(pathname, {accept: val}, function(data){
+    var pathname = window.location.pathname;
+    $.post(pathname, {accept: val}, function(data) {
         window.location.href = data.url;
     });
 }

--- a/core/static/js/profile.js
+++ b/core/static/js/profile.js
@@ -1,0 +1,11 @@
+function invite(val){
+    var group_id = $("#groupSelect").val();
+    var user_id = $("#userId").val();
+    var pathname = "/groups/" + group_id + "/join/";
+    $.post(pathname, {user: user_id}, function(data) {
+        window.location.reload();
+    });
+}
+
+
+$('#inviteBtn').click(invite);

--- a/core/templates/user/group.html
+++ b/core/templates/user/group.html
@@ -26,7 +26,7 @@
             </tr>
         {% empty %}
             <tr>
-                <td colspan="4">No members found.</td>
+                <td colspan="2">No members found.</td>
             </tr>
         {% endfor %}
         </tbody>
@@ -72,8 +72,10 @@
     {% if in_group %}
         <a href="{% url 'core:groups-leave' group.pk %}" class="btn btn-sm btn-danger"><i class="fa fa-minus fa-fw"></i>
             Leave Group</a>
-    {% else %}
+    {% elif request_sent %}
+        <p><em>Join request is pending...</em></p>
+    {% elif not request_sent %}
         <a href="{% url 'core:groups-join' group.pk %}" class="btn btn-sm btn-success"><i class="fa fa-plus fa-fw"></i>
-            Join Group</a>
+            Request to Join Group</a>
     {% endif %}
 {% endblock %}

--- a/core/templates/user/group.html
+++ b/core/templates/user/group.html
@@ -12,8 +12,6 @@
         <thead>
         <tr>
             <th>Member Name</th>
-            <th>TBD</th>
-            <th>TBD</th>
             <th>Actions</th>
         </tr>
         </thead>
@@ -21,8 +19,6 @@
         {% for member in group.members.all %}
             <tr {% if member.email == user.email %}class="success"{% endif %}>
                 <td>{{ member.display_name }}</td>
-                <td>N/A</td>
-                <td>N/A</td>
                 <td>
                     <a href="{% url 'core:profile:user-profile' member.pk %}" class="btn btn-sm btn-primary"><i
                             class="fa fa-search fa-fw"></i> View</a>
@@ -35,6 +31,44 @@
         {% endfor %}
         </tbody>
     </table>
+    <h4>Group Games</h4>
+        <table class="table table-bordered table-striped">
+            <thead>
+            <tr>
+                <th>Image</th>
+                <th>Game</th>
+                <th>Description</th>
+                <th>Group</th>
+                <th>Link</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for game in games %}
+                <tr>
+                    <td class="text-center">
+                        {% if game.image %}
+                            <img src="{{ game.image.thumbnail.url }}"
+                                 class="img-responsive img-rounded"
+                                 style="display: inline-block;">
+                        {% else %}
+                            <i class='fa fa-gamepad fa-5x'></i>
+                        {% endif %}
+                    </td>
+                    <td><strong class='text-capitalized'>{{ game.name }}</strong></td>
+                    <td>{{ game.small_description }}</td>
+                    <td>{{ game.group }}</td>
+                    <td>
+                        <a class="btn btn-primary" href="{% url 'core:games:specific' game_id=game.pk %}">View Game</a>
+                    </td>
+                </tr>
+            {% empty %}
+                <tr>
+                    <td colspan="5">No Games Found.</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+
     {% if in_group %}
         <a href="{% url 'core:groups-leave' group.pk %}" class="btn btn-sm btn-danger"><i class="fa fa-minus fa-fw"></i>
             Leave Group</a>

--- a/core/templates/user/groups.html
+++ b/core/templates/user/groups.html
@@ -6,7 +6,12 @@
     <div class="page-header">
         <h1>{{ page_title }}</h1>
     </div>
-    <table class="table table-bordered table-striped">
+
+    <div>
+    <a href="{% url 'core:groups-new' %}" class="btn btn-sm btn-success"><i class="fa fa-plus-circle fa-fw"></i> New
+        Group</a>
+    </div>
+    <table class="top10 table table-bordered table-striped">
         <thead>
         <tr>
             <th>Group Name</th>
@@ -33,6 +38,4 @@
         {% endfor %}
         </tbody>
     </table>
-    <a href="{% url 'core:groups-new' %}" class="btn btn-sm btn-success"><i class="fa fa-plus-circle fa-fw"></i> New
-        Group</a>
 {% endblock %}

--- a/core/templates/user/groups.html
+++ b/core/templates/user/groups.html
@@ -19,8 +19,8 @@
         {% for group in object_list %}
             <tr>
                 <td>{{ group.name }}</td>
-                <td>N/A</td>
-                <td>N/A</td>
+                <td>{{ group.members.all | length }}</td>
+                <td>{{ group.game_set.all | length }}</td>
                 <td>
                     <a href="{% url 'core:groups-detail' group.pk %}" class="btn btn-sm btn-primary"><i
                             class="fa fa-search fa-fw"></i> View</a>

--- a/core/templates/user/invitation.html
+++ b/core/templates/user/invitation.html
@@ -8,23 +8,24 @@
         <h1>Group Invitation</h1>
     </div>
     <div class="lead">
-    <p>
         {% if not viewable %}
+            <p>
             You do not have permission to view this invitation. Click <a href="{% url 'core:home' %}">here</a> to return home.
-        {% endif %}
-
-        {% if invite.inviting and is_user %}
-            Group "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>" would like you to join their group.
+            </p>
         {% else %}
-            User "<a href="{% url 'core:profile:user-profile' pk=invite.user.id %}">{{invite.user}}</a>" would like to join your group 
-                "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>".</p>
+            <p>
+            {% if invite.inviting and is_user %}
+                Group "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>" would like you to join their group.
+            {% else %}
+                User "<a href="{% url 'core:profile:user-profile' pk=invite.user.id %}">{{invite.user}}</a>" would like to join your group 
+                    "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>".</p>
+            {% endif %}
+            </p>
+            <div>
+                <button id="acceptBtn" class="btn btn-success"><i class="fa fa-check"></i> Accept</button>
+                <button id="declineBtn" class="btn btn-danger"><i class="fa fa-times"></i> Decline</button>
+            </div>
         {% endif %}
-
-    </p>
-    </div>
-    <div>
-        <button id="acceptBtn" class="btn btn-success"><i class="fa fa-check"></i> Accept</button>
-        <button id="declineBtn" class="btn btn-danger"><i class="fa fa-times"></i> Decline</button>
     </div>
 
 <script type="text/javascript" src="{% static "js/invite.js" %}"></script>

--- a/core/templates/user/invitation.html
+++ b/core/templates/user/invitation.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load staticfiles %}
 
 {% block title %}Group Invitation{% endblock %}
 
@@ -11,15 +12,20 @@
         {% if not viewable %}
             You do not have permission to view this invitation. Click <a href="{% url 'core:home' %}">here</a> to return home.
         {% endif %}
-        User "<a href="{% url 'core:profile:user-profile' pk=invite.user.id %}">{{invite.user}}</a>" would like to join your group 
-            "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>". Allow this? </p>
 
-        Group "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>" would like you to join their group. Allow this?
-        </div>
+        {% if invite.inviting and is_user %}
+            Group "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>" would like you to join their group.
+        {% else %}
+            User "<a href="{% url 'core:profile:user-profile' pk=invite.user.id %}">{{invite.user}}</a>" would like to join your group 
+                "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>".</p>
+        {% endif %}
+
     </p>
+    </div>
     <div>
-        <button class="btn btn-success"><i class="fa fa-check"></i> Accept</button>
-        <button class="btn btn-danger"><i class="fa fa-times"></i> Decline</button>
+        <button id="acceptBtn" class="btn btn-success"><i class="fa fa-check"></i> Accept</button>
+        <button id="declineBtn" class="btn btn-danger"><i class="fa fa-times"></i> Decline</button>
     </div>
 
+<script type="text/javascript" src="{% static "js/invite.js" %}"></script>
 {% endblock %}

--- a/core/templates/user/invitation.html
+++ b/core/templates/user/invitation.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}Group Invitation{% endblock %}
+
+{% block content %}
+    <div class="page-header">
+        <h1>Group Invitation</h1>
+    </div>
+    <div class="lead">
+    <p>
+        {% if not viewable %}
+            You do not have permission to view this invitation. Click <a href="{% url 'core:home' %}">here</a> to return home.
+        {% endif %}
+        User "<a href="{% url 'core:profile:user-profile' pk=invite.user.id %}">{{invite.user}}</a>" would like to join your group 
+            "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>". Allow this? </p>
+
+        Group "<a href="{% url 'core:groups-detail' pk=invite.user.id %}">{{invite.group}}</a>" would like you to join their group. Allow this?
+        </div>
+    </p>
+    <div>
+        <button class="btn btn-success"><i class="fa fa-check"></i> Accept</button>
+        <button class="btn btn-danger"><i class="fa fa-times"></i> Decline</button>
+    </div>
+
+{% endblock %}

--- a/core/templates/user/profile.html
+++ b/core/templates/user/profile.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load staticfiles %}
 
 {% block title %}Profile{% endblock %}
 {% block content %}
@@ -83,7 +84,23 @@
             </div>
         </div>
     </div>
+
+    {% if invite_groups %}
     <div class="row" style="border-top: solid 1px #eee; padding-top: 5px">
-        <h4 style="padding-left: 1.5rem">Recommended/Recently Played</h4>
+        <label>Invite This User to a Group</label>
+
+        <input id="userId" type="hidden" value="{{object.id}}"/>
+        <select id="groupSelect" class="form-control">
+            {% for group in invite_groups %}
+            <option value="{{group.id}}">{{group}}</option>
+            {% endfor %}
+        </select>
+        <div class="top10">
+        <button id="inviteBtn" class="btn btn-primary"><i class="fa fa-envelope"></i> Invite</button>
+        </div>
     </div>
+
+    {% endif %}
+
+<script type="text/javascript" src="{% static "js/profile.js" %}"></script>
 {% endblock %}

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -1,6 +1,8 @@
 from .utils import BaseViewTestCase as TestCase
 from django_dynamic_fixture import G
-from core.models import User, Group, Game, GameRating, UserNotification, GameTag
+from core.models import (User, Group, Game, GameRating,
+                         UserNotification, GameTag,
+                         GroupInvitation)
 from django.core.urlresolvers import reverse
 from datetime import datetime
 import json
@@ -116,9 +118,9 @@ class GroupJoinViewTestCase(TestCase):
     def test_join_group(self):
         user = self.client.login()
         group = G(Group)
-        self.assertNotIn(user, group.members.all())
+        self.assertNotExists(GroupInvitation, user=user)
         self.client.get(self.url(pk=group.pk))
-        self.assertIn(user, group.members.all())
+        self.assertExists(GroupInvitation, user=user)
 
 
 class GroupLeaveViewTestCase(TestCase):

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -80,6 +80,12 @@ class ProfileViewTestCase(TestCase):
         user = G(User)
         self.assertNoLoginRequired(pk=user.pk)
 
+    def test_login_get_successful(self):
+        user = G(User)
+        self.client.login()
+        response = self.client.get(self.url(pk=user.pk))
+        self.assertEqual(response.status_code, 200)
+
 
 class UserGroupsViewTestCase(TestCase):
     def url(self, *args, **kwargs):
@@ -121,6 +127,24 @@ class GroupJoinViewTestCase(TestCase):
         self.assertNotExists(GroupInvitation, user=user)
         self.client.get(self.url(pk=group.pk))
         self.assertExists(GroupInvitation, user=user)
+
+    def test_join_group_post(self):
+        user = self.client.login()
+        group = G(Group)
+        group.members = [user]
+        user2 = G(User)
+        self.assertNotExists(GroupInvitation, user=user2)
+        self.client.post(self.url(pk=group.pk), {"user": user2.id})
+        self.assertExists(GroupInvitation, user=user2)
+
+    def test_join_group_post_invalid(self):
+        user = self.client.login()
+        group = G(Group)
+        group.members = [user]
+        user2 = G(User)
+        self.assertNotExists(GroupInvitation, user=user2)
+        self.client.post(self.url(pk=group.pk))
+        self.assertNotExists(GroupInvitation, user=user2)
 
 
 class GroupLeaveViewTestCase(TestCase):
@@ -652,3 +676,38 @@ class UserNotificationViewTestCase(TestCase):
         notification = G(UserNotification, user=different_user)
         response = self.client.get(self.url(notification_id=notification.pk))
         self.assertEqual(response.status_code, 403)
+
+
+class GroupInvitationViewTestCase(TestCase):
+    def url(self, *args, **kwargs):
+        return reverse('core:invite', kwargs=kwargs)
+
+    def test_login_required(self):
+        invite = G(GroupInvitation)
+        self.assertLoginRequired(pk=invite.pk)
+
+    def test_get(self):
+        self.client.login()
+        invite = G(GroupInvitation)
+        response = self.client.get(self.url(pk=invite.pk))
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_accept(self):
+        user = self.client.login()
+        invite = G(GroupInvitation, user=user, inviting=True)
+        group = invite.group
+        self.assertNotIn(user, group.members.all())
+
+        self.client.post(self.url(pk=invite.pk), {"accept": True})
+        self.assertIn(user, group.members.all())
+        self.assertNotExists(GroupInvitation, user=user)
+
+    def test_post_decline(self):
+        user = self.client.login()
+        invite = G(GroupInvitation, user=user, inviting=True)
+        group = invite.group
+        self.assertNotIn(user, group.members.all())
+
+        self.client.post(self.url(pk=invite.pk), {"accept": False})
+        self.assertNotIn(user, group.members.all())
+        self.assertNotExists(GroupInvitation, user=user)

--- a/core/urls/base.py
+++ b/core/urls/base.py
@@ -24,7 +24,7 @@ urlpatterns = patterns(
     url(r'^groups/(?P<pk>\d+)/$', GroupDetailView.as_view(), name='groups-detail'),
     url(r'^groups/(?P<pk>\d+)/join/$', GroupJoinView.as_view(), name='groups-join'),
     url(r'^groups/(?P<pk>\d+)/leave/$', GroupLeaveView.as_view(), name='groups-leave'),
-    url(r'^invite/(?P<pk>\d+)/$', GroupInvitationView.as_view(), name='invitation'),
+    url(r'^invite/(?P<pk>\d+)/$', GroupInvitationView.as_view(), name='invite'),
     url(r'^groups/new/$', GroupCreateView.as_view(), name='groups-new'),
 
     # Login urls

--- a/core/urls/base.py
+++ b/core/urls/base.py
@@ -16,9 +16,9 @@ urlpatterns = patterns(
     url(r'^games/', include('core.urls.games', namespace="games")),
     url(r'^register/$', register, name='register'),
 
-    # TODO: Separate user urls out
     url(r'^profile/', include('core.urls.profile', namespace='profile')),
 
+    # Group urls
     url(r'^user/groups/$', UserGroupsView.as_view(), name='user-groups'),
     url(r'^groups/$', GroupsView.as_view(), name='groups'),
     url(r'^groups/(?P<pk>\d+)/$', GroupDetailView.as_view(), name='groups-detail'),
@@ -26,6 +26,8 @@ urlpatterns = patterns(
     url(r'^groups/(?P<pk>\d+)/leave/$', GroupLeaveView.as_view(), name='groups-leave'),
     url(r'^invite/(?P<pk>\d+)/$', GroupInvitationView.as_view(), name='invitation'),
     url(r'^groups/new/$', GroupCreateView.as_view(), name='groups-new'),
+
+    # Login urls
     url(r'^login/$', 'django.contrib.auth.views.login', name='login'),
     url(r'^logout/$', 'django.contrib.auth.views.logout',
         {'next_page': 'core:home'}, name='logout'),

--- a/core/urls/base.py
+++ b/core/urls/base.py
@@ -3,7 +3,7 @@ from django.conf.urls import patterns, url, include
 from django.conf.urls.static import static
 from core.views import (Home, register, UserGroupsView,
                         GroupsView, GroupDetailView, GroupJoinView,
-                        GroupLeaveView, GroupCreateView)
+                        GroupLeaveView, GroupCreateView, GroupInvitationView)
 
 # Use this file to import all other url
 from game_website import settings
@@ -24,6 +24,7 @@ urlpatterns = patterns(
     url(r'^groups/(?P<pk>\d+)/$', GroupDetailView.as_view(), name='groups-detail'),
     url(r'^groups/(?P<pk>\d+)/join/$', GroupJoinView.as_view(), name='groups-join'),
     url(r'^groups/(?P<pk>\d+)/leave/$', GroupLeaveView.as_view(), name='groups-leave'),
+    url(r'^invite/(?P<pk>\d+)/$', GroupInvitationView.as_view(), name='invitation'),
     url(r'^groups/new/$', GroupCreateView.as_view(), name='groups-new'),
     url(r'^login/$', 'django.contrib.auth.views.login', name='login'),
     url(r'^logout/$', 'django.contrib.auth.views.logout',

--- a/core/views/notifications.py
+++ b/core/views/notifications.py
@@ -7,7 +7,7 @@ from core.models import UserNotification
 def base(request, notification_id):
     """URL that marks the notification read then redirects"""
     notification = UserNotification.objects.get(pk=notification_id)
-    if notification.user.pk is not request.user.pk:
+    if int(notification.user.pk) != int(request.user.pk):
         response = HttpResponse(status=403)
     else:
         response = HttpResponseRedirect(notification.redirect_url)

--- a/core/views/users.py
+++ b/core/views/users.py
@@ -123,6 +123,7 @@ class GroupDetailView(DetailView):
         """Set the page title."""
         context = super(GroupDetailView, self).get_context_data(**kwargs)
         context["in_group"] = self.request.user in self.object.members.all()
+        context["games"] = self.object.game_set.all()
         return context
 
 

--- a/core/views/users.py
+++ b/core/views/users.py
@@ -176,11 +176,13 @@ class GroupInvitationView(LoginRequiredMixin, DetailView):
         return context
 
     def post(self, request, *args, **kwargs):
-        # Don't worry about invalid posts
+        # Don't do anything about invalid posts
         invite = self.get_object()
         group = invite.group
         if invite.valid_user(request.user):
             accept = request.POST.get('accept')
+            # Convert from a string here
+            accept = {'True': True, 'False': False}.get(accept)
             if accept:
                 invite.accept()
             elif accept is False:

--- a/core/views/users.py
+++ b/core/views/users.py
@@ -72,7 +72,7 @@ class ProfileView(DetailView):
         groups = Group.objects.filter(members=user)
         context['games_list'] = Game.objects.filter(group__in=groups)
         context['show_edit'] = user.pk is self.request.user.pk
-        if self.request.user and self.request.user != user:
+        if self.request.user and self.request.user != user and hasattr(self.request.user, 'group_set'):
             invite_groups = set(self.request.user.group_set.all())
             invite_groups -= set(groups)
             pending_invites = set(i.group for i in GroupInvitation.objects.filter(user=user))


### PR DESCRIPTION
This has a few fixes to the groups pages (fix tables, add games to groups) and allows both requesting to join groups and inviting users to groups.

If you're not in a group, a little 'request to join' button should appear at the buttom:
![screen shot 2015-04-25 at 10 15 40 pm](https://cloud.githubusercontent.com/assets/4104448/7335593/b4bb1c22-eb98-11e4-9894-82eb81815d9d.png)

If you view a user's profile and they aren't in a group you are in, you'll get the option to invite them to groups:
![screen shot 2015-04-25 at 10 16 36 pm](https://cloud.githubusercontent.com/assets/4104448/7335597/cf76a770-eb98-11e4-8e9d-d2625d062fc6.png)

If you're inviting someone to join your group, they'll see:
![screen shot 2015-04-25 at 10 18 03 pm](https://cloud.githubusercontent.com/assets/4104448/7335599/0863153c-eb99-11e4-8a48-485898818587.png)

If you request to join someone's group, they'll see:
![screen shot 2015-04-25 at 10 18 19 pm](https://cloud.githubusercontent.com/assets/4104448/7335602/1c3a44ae-eb99-11e4-880f-ca83d8229927.png)
